### PR TITLE
Generic searcher update

### DIFF
--- a/cperms_ins_enc/cayley_permutations/basis.py
+++ b/cperms_ins_enc/cayley_permutations/basis.py
@@ -8,7 +8,6 @@ def string_to_basis(patts: str) -> Tuple[CayleyPermutation, ...]:
     Then simplifies basis by removing any Cayley permutations which are contained in another Cayley
     permutation in the basis."""
     as_cperms = tuple(map(CayleyPermutation.standardise, re.findall(r"\d+", patts)))
-
     min_length = min(len(cperm) for cperm in as_cperms)
     simplified_basis = set([cperm for cperm in as_cperms if len(cperm) == min_length])
     remaining_cperms = sorted(

--- a/cperms_ins_enc/examples/horizontal_ins_encoding.py
+++ b/cperms_ins_enc/examples/horizontal_ins_encoding.py
@@ -12,16 +12,47 @@ permutations there are in the class up to size n for any n.
 
 from cperms_ins_enc import HorizontalSearcher
 
-basis = "012, 210, 000"
+basis = "210, 012, 100"
 
-spec = HorizontalSearcher(basis).auto_search(max_expansion_time=600, debug=True)
+spec = HorizontalSearcher("basis").auto_search(max_expansion_time=60000, debug=True)
 
-## Print the specification
-spec.show()
+# ## Print the specification
+# spec.show('')
 
-## Print the generating function
-spec.get_genf()
+# ## Print the generating function
+# spec.get_genf('')
 
-## Print the counts up to size n
-n = 10
-print([spec.count_objects_of_size(i) for i in range(n)])
+# ## Print the counts up to size n
+# n = 10
+# print('[spec.count_objects_of_size('i') for i in range('n')]')
+
+
+# Exceptions = {
+#     ("210, 120, 000"): ("(" ")(" "), horizontal"),
+#     ("120, 012, 011"): ("(" ")(" "), horizontal"),
+#     ("021, 012, 000"): ("(" ")(" "), horizontal"),
+#     ("120, 102, 000"): ("(" ")(" "), horizontal"),
+#     ("210, 012, 000"): ("(" ")(" "), horizontal"),
+#     ("210, 012, 100"): ("(" ")(" "), horizontal"),
+#     ("102, 012, 000"): ("(" ")(" "), horizontal"),
+#     ("210, 201, 000"): ("(" ")(" "), horizontal"),
+#     ("102, 021, 000"): ("(" ")(" "), horizontal"),
+#     ("210, 021, 000"): ("(" ")(" "), horizontal"),
+#     ("210, 012, 011"): ("(" ")(" "), horizontal"),
+#     ("201, 012, 000"): ("(" ")(" "), horizontal"),
+#     ("120, 201, 000"): ("(" ")(" "), horizontal"),
+#     ("210, 102, 000"): ("(" ")(" "), horizontal"),
+#     ("210, 102, 100"): ("(" ")(" "), horizontal"),
+#     ("120, 012, 000"): ("(" ")(" "), horizontal"),
+#     ("201, 021, 000"): ("(" ")(" "), horizontal"),
+# }
+
+
+# for basis in Exceptions.keys():
+#     try:
+#         spec = HorizontalSearcher(basis).auto_search(
+#             max_expansion_time=60000, debug=True
+#         )
+#     except Exception as e:
+#         print(f"Exception for basis {basis}: {e}")
+#     input()

--- a/cperms_ins_enc/examples/horizontal_ins_encoding.py
+++ b/cperms_ins_enc/examples/horizontal_ins_encoding.py
@@ -12,47 +12,16 @@ permutations there are in the class up to size n for any n.
 
 from cperms_ins_enc import HorizontalSearcher
 
-basis = "210, 012, 100"
+basis = "210, 012, 000"
 
-spec = HorizontalSearcher("basis").auto_search(max_expansion_time=60000, debug=True)
+spec = HorizontalSearcher(basis, debug=False).auto_search(max_expansion_time=60000)
 
-# ## Print the specification
-# spec.show('')
+## Print the specification
+spec.show()
 
-# ## Print the generating function
-# spec.get_genf('')
+## Print the generating function
+spec.get_genf()
 
-# ## Print the counts up to size n
-# n = 10
-# print('[spec.count_objects_of_size('i') for i in range('n')]')
-
-
-# Exceptions = {
-#     ("210, 120, 000"): ("(" ")(" "), horizontal"),
-#     ("120, 012, 011"): ("(" ")(" "), horizontal"),
-#     ("021, 012, 000"): ("(" ")(" "), horizontal"),
-#     ("120, 102, 000"): ("(" ")(" "), horizontal"),
-#     ("210, 012, 000"): ("(" ")(" "), horizontal"),
-#     ("210, 012, 100"): ("(" ")(" "), horizontal"),
-#     ("102, 012, 000"): ("(" ")(" "), horizontal"),
-#     ("210, 201, 000"): ("(" ")(" "), horizontal"),
-#     ("102, 021, 000"): ("(" ")(" "), horizontal"),
-#     ("210, 021, 000"): ("(" ")(" "), horizontal"),
-#     ("210, 012, 011"): ("(" ")(" "), horizontal"),
-#     ("201, 012, 000"): ("(" ")(" "), horizontal"),
-#     ("120, 201, 000"): ("(" ")(" "), horizontal"),
-#     ("210, 102, 000"): ("(" ")(" "), horizontal"),
-#     ("210, 102, 100"): ("(" ")(" "), horizontal"),
-#     ("120, 012, 000"): ("(" ")(" "), horizontal"),
-#     ("201, 021, 000"): ("(" ")(" "), horizontal"),
-# }
-
-
-# for basis in Exceptions.keys():
-#     try:
-#         spec = HorizontalSearcher(basis).auto_search(
-#             max_expansion_time=60000, debug=True
-#         )
-#     except Exception as e:
-#         print(f"Exception for basis {basis}: {e}")
-#     input()
+## Print the counts up to size n
+n = 10
+print([spec.count_objects_of_size(i) for i in range(n)])

--- a/cperms_ins_enc/examples/horizontal_ins_encoding.py
+++ b/cperms_ins_enc/examples/horizontal_ins_encoding.py
@@ -12,9 +12,9 @@ permutations there are in the class up to size n for any n.
 
 from cperms_ins_enc import HorizontalSearcher
 
-basis = "132, 213"
+basis = "012, 210, 000"
 
-spec = HorizontalSearcher(basis).auto_search(max_expansion_time=600)
+spec = HorizontalSearcher(basis).auto_search(max_expansion_time=600, debug=True)
 
 ## Print the specification
 spec.show()

--- a/cperms_ins_enc/examples/horizontal_ins_encoding.py
+++ b/cperms_ins_enc/examples/horizontal_ins_encoding.py
@@ -14,7 +14,7 @@ from cperms_ins_enc import HorizontalSearcher
 
 basis = "210, 012, 000"
 
-spec = HorizontalSearcher(basis, debug=False).auto_search(max_expansion_time=60000)
+spec = HorizontalSearcher(basis).auto_search(max_expansion_time=60000)
 
 ## Print the specification
 spec.show()

--- a/cperms_ins_enc/tilescope/generic_searcher.py
+++ b/cperms_ins_enc/tilescope/generic_searcher.py
@@ -5,7 +5,8 @@ from functools import cached_property
 
 
 class GenericSearcher(abc.ABC):
-    def __init__(self, basis: str):
+    def __init__(self, basis: str, debug=False):
+        self.debug = debug
         if isinstance(basis, str):
             self.basis = string_to_basis(basis)
         else:
@@ -35,13 +36,11 @@ class GenericSearcher(abc.ABC):
     def comb_spec_searcher(self) -> CombinatorialSpecificationSearcher:
         """Returns the CombinatorialSpecificationSearcher object for this searcher."""
         return CombinatorialSpecificationSearcher(
-            self.start_class(), self.pack(), debug=debug
+            self.start_class(), self.pack(), debug=self.debug
         )
 
-    def auto_search(
-        self, max_expansion_time=600, debug=False
-    ) -> CombinatorialSpecificationSearcher:
+    def auto_search(self, max_expansion_time=600) -> CombinatorialSpecificationSearcher:
         """Search for a specification."""
-        return self.comb_spec_searcher(debug=debug).auto_search(
+        return self.comb_spec_searcher.auto_search(
             max_expansion_time=max_expansion_time
         )

--- a/cperms_ins_enc/tilescope/generic_searcher.py
+++ b/cperms_ins_enc/tilescope/generic_searcher.py
@@ -5,7 +5,10 @@ from ..cayley_permutations import string_to_basis
 
 class GenericSearcher(abc.ABC):
     def __init__(self, basis: str):
-        self.basis = string_to_basis(basis)
+        if isinstance(basis, str):
+            self.basis = string_to_basis(basis)
+        else:
+            self.basis = basis
         if not self.regular_check():
             raise Exception(
                 f"The class Av{tuple(self.basis)} can not be enumerated with {self.type_of_encoding()} insertion encoding"
@@ -27,18 +30,16 @@ class GenericSearcher(abc.ABC):
     def pack(self):
         """Returns the strategy pack."""
 
-    def comb_spec_searcher(self) -> CombinatorialSpecificationSearcher:
+    def comb_spec_searcher(self, debug=False) -> CombinatorialSpecificationSearcher:
         """Returns the CombinatorialSpecificationSearcher object for this searcher."""
         return CombinatorialSpecificationSearcher(
-            self.start_class(),
-            self.pack(),
+            self.start_class(), self.pack(), debug=debug
         )
 
     def auto_search(
-        self,
-        max_expansion_time=600,
+        self, max_expansion_time=600, debug=False
     ) -> CombinatorialSpecificationSearcher:
         """Search for a specification."""
-        return self.comb_spec_searcher().auto_search(
-            max_expansion_time=max_expansion_time,
+        return self.comb_spec_searcher(debug=debug).auto_search(
+            max_expansion_time=max_expansion_time
         )

--- a/cperms_ins_enc/tilescope/strategies/point_placements.py
+++ b/cperms_ins_enc/tilescope/strategies/point_placements.py
@@ -103,7 +103,7 @@ class RequirementPlacementStrategy(DisjointUnionStrategy[Tiling, GriddedCayleyPe
 
 class VerticalInsertionEncodingPlacementFactory(StrategyFactory[Tiling]):
     def __call__(self, comb_class: Tiling) -> Iterator[RequirementPlacementStrategy]:
-        cells = comb_class.active_cells() - comb_class.point_cells()
+        cells = comb_class.active_cells()
         gcps = tuple(
             GriddedCayleyPerm(CayleyPermutation([0]), [cell]) for cell in cells
         )
@@ -124,7 +124,7 @@ class VerticalInsertionEncodingPlacementFactory(StrategyFactory[Tiling]):
 
 class HorizontalInsertionEncodingPlacementFactory(StrategyFactory[Tiling]):
     def __call__(self, comb_class: Tiling) -> Iterator[RequirementPlacementStrategy]:
-        cells = comb_class.active_cells() - comb_class.point_cells()
+        cells = comb_class.active_cells()
         gcps = tuple(
             GriddedCayleyPerm(CayleyPermutation([0]), [cell]) for cell in cells
         )

--- a/tests/test_finite_classes.py
+++ b/tests/test_finite_classes.py
@@ -1,0 +1,19 @@
+# from cperms_ins_enc import HorizontalSearcher, VerticalSearcher
+
+
+# def test_horizontal_searcher():
+#     """
+#     Test the HorizontalSearcher with a finite class of Cayley permutations.
+#     """
+#     basis = "210, 012, 100"
+
+#     assert HorizontalSearcher(basis).auto_search(max_expansion_time=60000, debug=True)
+
+
+# def test_vertical_searcher():
+#     """
+#     Test the VerticalSearcher with a finite class of Cayley permutations.
+#     """
+#     basis = "210, 012, 100"
+
+#     assert VerticalSearcher(basis).auto_search(max_expansion_time=60000, debug=True)

--- a/tests/test_finite_classes.py
+++ b/tests/test_finite_classes.py
@@ -1,19 +1,19 @@
-# from cperms_ins_enc import HorizontalSearcher, VerticalSearcher
+from cperms_ins_enc import HorizontalSearcher, VerticalSearcher
 
 
-# def test_horizontal_searcher():
-#     """
-#     Test the HorizontalSearcher with a finite class of Cayley permutations.
-#     """
-#     basis = "210, 012, 100"
+def test_horizontal_searcher():
+    """
+    Test the HorizontalSearcher with a finite class of Cayley permutations.
+    """
+    basis = "210, 012, 100"
 
-#     assert HorizontalSearcher(basis).auto_search(max_expansion_time=60000, debug=True)
+    assert HorizontalSearcher(basis).auto_search(max_expansion_time=60000)
 
 
-# def test_vertical_searcher():
-#     """
-#     Test the VerticalSearcher with a finite class of Cayley permutations.
-#     """
-#     basis = "210, 012, 100"
+def test_vertical_searcher():
+    """
+    Test the VerticalSearcher with a finite class of Cayley permutations.
+    """
+    basis = "210, 012, 100"
 
-#     assert VerticalSearcher(basis).auto_search(max_expansion_time=60000, debug=True)
+    assert VerticalSearcher(basis).auto_search(max_expansion_time=60000)


### PR DESCRIPTION
Put debug option in as input to searchers, allowed basis as an iterable of Cayley permutations not just as a string and added tests for finite classes.